### PR TITLE
Fixed a bug, which caused a JsonSerializationException

### DIFF
--- a/PaymillWrapper/Models/Fee.cs
+++ b/PaymillWrapper/Models/Fee.cs
@@ -45,8 +45,5 @@ namespace PaymillWrapper.Models
 
         [DataMember(Name = "currency")]
         public String Currency { get; set; }
-
-        [DataMember(Name = "application")]
-        public String application{ get; set; }
     }
 }


### PR DESCRIPTION
Fixed a bug, which was caused, because there where two fields in the Fee class, ("Application" and "application"), which where both marked as JSON properties with the same name ("application"). This caused a JsonSerializationException. The bug was fixed by removing the (probably deprecated) property "application".